### PR TITLE
Maya users backend

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -2,8 +2,11 @@
   "name": "backend",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
+  "main": "src/server.js",
+  "type": "module",
   "scripts": {
+    "start": "node src/server.js",
+    "dev": "nodemon src/server.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],

--- a/backend/src/app.js
+++ b/backend/src/app.js
@@ -7,7 +7,6 @@ import userRoutes from "./routes/user.routes.js";
 const app = express();
 
 app.use(express.json());
-
 app.use(loggerMiddleware);
 
 app.get("/", (req, res) => {
@@ -15,8 +14,9 @@ app.get("/", (req, res) => {
 });
 
 app.use("/auth", authRoutes);
-
-app.use(errorMiddleware);
 app.use("/users", userRoutes);
+
+// errorMiddleware must be last
+app.use(errorMiddleware);
 
 export default app;

--- a/backend/src/constants/roles.js
+++ b/backend/src/constants/roles.js
@@ -1,0 +1,6 @@
+const ROLES = {
+  USER: "user",
+  ADMIN: "admin"
+};
+
+export default ROLES;

--- a/backend/src/controllers/user.controller.js
+++ b/backend/src/controllers/user.controller.js
@@ -1,0 +1,73 @@
+import userService from "../services/user.service.js";
+
+export const getMe = async (req, res, next) => {
+  try {
+    const user = await userService.getMe(req.user.id);
+    res.json(user);
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const updateMe = async (req, res, next) => {
+  try {
+    const user = await userService.updateMe(req.user.id, req.body);
+    res.json(user);
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const followUser = async (req, res, next) => {
+  try {
+    const result = await userService.followUser(req.user.id, req.params.id);
+
+    res.status(201).json(result);
+  } catch (error) {
+    next(error);
+  }
+};
+
+
+export const unfollowUser = async (req, res, next) => {
+  try {
+    const result = await userService.unfollowUser(req.user.id, req.params.id);
+
+    res.json(result);
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const getFollowers = async (req, res, next) => {
+  try {
+    const followers = await userService.getFollowers(req.params.id);
+
+    res.json(followers);
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const getFollowing = async (req, res, next) => {
+  try {
+    const following = await userService.getFollowing(req.params.id);
+
+    res.json(following);
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const updateNotificationPreferences = async (req, res, next) => {
+  try {
+    const prefs = await userService.updateNotificationPreferences(
+      req.user.id,
+      req.body
+    );
+
+    res.json(prefs);
+  } catch (error) {
+    next(error);
+  }
+};

--- a/backend/src/models/follower.model.js
+++ b/backend/src/models/follower.model.js
@@ -1,0 +1,28 @@
+import mongoose from "mongoose";
+
+const followerSchema = new mongoose.Schema(
+  {
+    follower: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "User",
+      required: true
+    },
+    following: {
+      type: mongoose.Schema.Types.ObjectId,
+      ref: "User",
+      required: true
+    }
+  },
+  { timestamps: true }
+);
+
+// Prevent duplicate follow relationships
+followerSchema.index({ follower: 1, following: 1 }, { unique: true });
+
+// Efficiently query "who follows userId" and "who does userId follow"
+followerSchema.index({ following: 1 });
+followerSchema.index({ follower: 1 });
+
+const Follower = mongoose.model("Follower", followerSchema);
+
+export default Follower;

--- a/backend/src/models/user.model.js
+++ b/backend/src/models/user.model.js
@@ -1,0 +1,66 @@
+import mongoose from "mongoose";
+import ROLES from "../constants/roles.js";
+
+const notificationPreferencesSchema = new mongoose.Schema(
+  {
+    newFollower: { type: Boolean, default: true },
+    newComment: { type: Boolean, default: true },
+    newLike: { type: Boolean, default: true }
+  },
+  { _id: false }
+);
+
+const userSchema = new mongoose.Schema(
+  {
+    username: {
+      type: String,
+      required: true,
+      unique: true,
+      trim: true,
+      minlength: 3,
+      maxlength: 30
+    },
+    email: {
+      type: String,
+      required: true,
+      unique: true,
+      lowercase: true,
+      trim: true
+    },
+    password: {
+      type: String,
+      required: true,
+      minlength: 8
+    },
+    role: {
+      type: String,
+      enum: Object.values(ROLES),
+      default: ROLES.USER
+    },
+    bio: {
+      type: String,
+      maxlength: 300,
+      default: ""
+    },
+    avatarUrl: {
+      type: String,
+      default: ""
+    },
+    notificationPreferences: {
+      type: notificationPreferencesSchema,
+      default: () => ({})
+    }
+  },
+  { timestamps: true }
+);
+
+// Never return the password in query results
+userSchema.methods.toJSON = function () {
+  const obj = this.toObject();
+  delete obj.password;
+  return obj;
+};
+
+const User = mongoose.model("User", userSchema);
+
+export default User;

--- a/backend/src/routes/user.routes.js
+++ b/backend/src/routes/user.routes.js
@@ -1,0 +1,32 @@
+import express from "express";
+import authMiddleware from "../middleware/auth.middleware.js";
+import {
+  getMe,
+  updateMe,
+  followUser,
+  unfollowUser,
+  getFollowers,
+  getFollowing,
+  updateNotificationPreferences
+} from "../controllers/user.controller.js";
+
+const router = express.Router();
+
+// All user routes require authentication
+router.use(authMiddleware);
+
+// Profile
+router.get("/me", getMe);
+router.patch("/updateMe", updateMe);
+
+// Notification preferences
+// NOTE: this must be defined before /:id routes to avoid "me" being treated as an id
+router.patch("/me/notifications", updateNotificationPreferences);
+
+// Social graph
+router.post("/:id/follow", followUser);
+router.delete("/:id/follow", unfollowUser);
+router.get("/:id/followers", getFollowers);
+router.get("/:id/following", getFollowing);
+
+export default router;

--- a/backend/src/services/user.service.js
+++ b/backend/src/services/user.service.js
@@ -1,0 +1,145 @@
+import User from "../models/user.model.js";
+import ApiError from "../utils/ApiError.js";
+import Follower from "../models/follower.model.js";
+
+const getMe = async (userId) => {
+  const user = await User.findById(userId);
+
+  if (!user) throw new ApiError(404, "User not found");
+
+  return user;
+};
+
+const ALLOWED_UPDATE_FIELDS = ["username", "bio", "avatarUrl"];
+
+const updateMe = async (userId, data) => {
+  // Strip any fields the user is not allowed to change
+  const updates = Object.fromEntries(
+    Object.entries(data).filter(([key]) => ALLOWED_UPDATE_FIELDS.includes(key))
+  );
+
+  if (Object.keys(updates).length === 0) {
+    throw new ApiError(400, "No valid fields provided for update");
+  }
+
+  const user = await User.findByIdAndUpdate(
+    userId,
+    { $set: updates },
+    { new: true, runValidators: true }
+  );
+
+  if (!user) throw new ApiError(404, "User not found");
+
+  return user;
+};
+
+const followUser = async (followerId, targetId) => {
+  if (followerId === targetId) {
+    throw new ApiError(400, "You cannot follow yourself");
+  }
+
+  const targetUser = await User.findById(targetId);
+  if (!targetUser) throw new ApiError(404, "User not found");
+
+  const alreadyFollowing = await Follower.findOne({
+    follower: followerId,
+    following: targetId
+  });
+
+  if (alreadyFollowing) {
+    throw new ApiError(409, "You are already following this user");
+  }
+
+  await Follower.create({ follower: followerId, following: targetId });
+
+  return { message: "Followed successfully" };
+};
+
+const unfollowUser = async (followerId, targetId) => {
+  if (followerId === targetId) {
+    throw new ApiError(400, "You cannot unfollow yourself");
+  }
+
+  const relationship = await Follower.findOneAndDelete({
+    follower: followerId,
+    following: targetId
+  });
+
+  if (!relationship) {
+    throw new ApiError(404, "You are not following this user");
+  }
+
+  return { message: "Unfollowed successfully" };
+};
+
+const getFollowers = async (userId) => {
+  const user = await User.findById(userId);
+  if (!user) throw new ApiError(404, "User not found");
+
+  const followers = await Follower.find({ following: userId })
+    .populate("follower", "username avatarUrl bio")
+    .sort({ createdAt: -1 });
+
+  return followers.map((f) => f.follower);
+};
+
+const getFollowing = async (userId) => {
+  const user = await User.findById(userId);
+  if (!user) throw new ApiError(404, "User not found");
+
+  const following = await Follower.find({ follower: userId })
+    .populate("following", "username avatarUrl bio")
+    .sort({ createdAt: -1 });
+
+  return following.map((f) => f.following);
+};
+
+const ALLOWED_NOTIFICATION_FIELDS = ["newFollower", "newComment", "newLike"];
+
+const updateNotificationPreferences = async (userId, preferences) => {
+  const updates = Object.fromEntries(
+    Object.entries(preferences).filter(([key]) =>
+      ALLOWED_NOTIFICATION_FIELDS.includes(key)
+    )
+  );
+
+  if (Object.keys(updates).length === 0) {
+    throw new ApiError(400, "No valid notification preference fields provided");
+  }
+
+  // Build a $set payload scoped to the notificationPreferences subdocument
+  const setPayload = Object.fromEntries(
+    Object.entries(updates).map(([key, val]) => [
+      `notificationPreferences.${key}`,
+      val
+    ])
+  );
+
+  const user = await User.findByIdAndUpdate(
+    userId,
+    { $set: setPayload },
+    { new: true, runValidators: true }
+  );
+
+  if (!user) throw new ApiError(404, "User not found");
+
+  return user.notificationPreferences;
+};
+
+export default {
+  getMe,
+  updateMe,
+  followUser,
+  unfollowUser,
+  getFollowers,
+  getFollowing,
+  updateNotificationPreferences
+};
+
+
+
+
+
+
+
+

--- a/backend/src/utils/ApiError.js
+++ b/backend/src/utils/ApiError.js
@@ -1,0 +1,9 @@
+class ApiError extends Error {
+  constructor(statusCode, message) {
+    super(message);
+    this.statusCode = statusCode;
+    Error.captureStackTrace(this, this.constructor);
+  }
+}
+
+export default ApiError;


### PR DESCRIPTION
Closes #9, #10, #11, #12, #13, #14, #15, #16, #17

## What this PR does
Implements the complete user profile system, social follow/unfollow functionality, and notification preferences for the ClipSphere backend.

## Endpoints added
- GET /users/me — get my profile
- PATCH /users/updateMe — update bio, username, avatarUrl
- POST /users/:id/follow — follow a user
- DELETE /users/:id/follow — unfollow a user
- GET /users/:id/followers — get followers list
- GET /users/:id/following — get following list
- PATCH /users/me/notifications — update notification preferences

## New files
- src/models/user.model.js
- src/models/follower.model.js
- src/constants/roles.js
- src/utils/ApiError.js

## Testing
All endpoints tested manually via Postman including happy path, auth errors, duplicate follow, self-follow protection, and invalid field updates.